### PR TITLE
多次 load 导致的异常

### DIFF
--- a/lib/js_namespace_rails/action_view/helpers/asset_tag_helper.rb
+++ b/lib/js_namespace_rails/action_view/helpers/asset_tag_helper.rb
@@ -1,15 +1,17 @@
-
 module ActionView::Helpers::AssetTagHelper
 
-  alias_method :javascript_include_tag_without_controller, :javascript_include_tag
+  # load twice will raise exception 'stack level too deep'
+  unless defined?(:javascript_include_tag_without_controller)    
+    alias_method :javascript_include_tag_without_controller, :javascript_include_tag
 
-  def javascript_include_tag(*source)
+    def javascript_include_tag(*source)
 
-    if defined?(controller_path) && !@_included
-      @_included = true
-      concat javascript_tag(insert_hook_script, defer: 'defer')
+      if defined?(controller_path) && !@_included
+        @_included = true
+        concat javascript_tag(insert_hook_script, defer: 'defer')
+      end
+      javascript_include_tag_without_controller(*source)
     end
-    javascript_include_tag_without_controller(*source)
   end
 
 end


### PR DESCRIPTION
项目中引入了 bootsnap，计算加载路径的时候，同时出现两个 js-namespace-rails 的目录/var/home/ 和 /var/apps/ ，两次加载的了打开类，`lib/js_namespace_rails/action_view/helpers/asset_tag_helper.rb` 就会出现循环定义的问题。

```
module ActionView::Helpers::AssetTagHelper

    alias_method :javascript_include_tag_without_controller, :javascript_include_tag

    def javascript_include_tag(*source)

      if defined?(controller_path) && !@_included
        @_included = true
        concat javascript_tag(insert_hook_script, defer: 'defer')
      end
      javascript_include_tag_without_controller(*source)
    end

   alias_method :javascript_include_tag_without_controller, :javascript_include_tag

    def javascript_include_tag(*source)

      if defined?(controller_path) && !@_included
        @_included = true
        concat javascript_tag(insert_hook_script, defer: 'defer')
      end
      javascript_include_tag_without_controller(*source)
    end

end
```
最终导致后台无法打开。
